### PR TITLE
Add support for uniqueItems in an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This gem allows to convert [Kwalify](http://www.kuwata-lab.com/kwalify/) schemas
 
 ```console
 gem install kwalify_to_json_schema
-``` 
+```
 
 ## Limitations
 
@@ -18,7 +18,7 @@ The current implementation has the following limitations:
 
 * Kwalify 'time' type is not supported and is ignored
 * Kwalify 'timestamp' type is not supported and is ignored
-* Kwalify 'unique' is not supported by JSON Schema and is ignored
+* Kwalify 'unique' within a mapping is not supported by JSON Schema and is ignored
 * Kwalify mapping default value is not supported by JSON Schema and is ignored
 * Kwalify 'date' type is not supported and is ignored
 
@@ -64,7 +64,7 @@ class CustomProcessing
     def preprocess(kwalify_schema)
       # TODO return modified schema
     end
-    
+
     # The method will be called after the conversion allowing to customize the output JSON schema.
     # The implementation have to return the modified schema.
     # The default implemention don't modify the schema.

--- a/lib/kwalify_to_json_schema/converter.rb
+++ b/lib/kwalify_to_json_schema/converter.rb
@@ -99,7 +99,13 @@ module KwalifyToJsonSchema
         target["type"] = "array"
         sequence = kelem["sequence"]
         if sequence.is_a? Array
-          process(target["items"] = {}, sequence.first)
+          rule = sequence.first
+          if rule["unique"]
+            target["uniqueItems"] = true
+            rule = rule.dup
+            rule.delete("unique")
+          end
+          process(target["items"] = {}, rule)
         end
       when "str"
         target["type"] = "string"

--- a/lib/kwalify_to_json_schema/limitations.rb
+++ b/lib/kwalify_to_json_schema/limitations.rb
@@ -4,7 +4,7 @@ module KwalifyToJsonSchema
     DATE_TYPE_NOT_IMPLEMENTED = "Kwalify 'date' type is not supported and is ignored"
     TIME_TYPE_NOT_IMPLEMENTED = "Kwalify 'time' type is not supported and is ignored"
     TIMESTAMP_TYPE_NOT_IMPLEMENTED = "Kwalify 'timestamp' type is not supported and is ignored"
-    UNIQUE_NOT_SUPPORTED = "Kwalify 'unique' is not supported by JSON Schema and is ignored"
+    UNIQUE_NOT_SUPPORTED = "Kwalify 'unique' within a mapping is not supported by JSON Schema and is ignored"
     MAPPING_DEFAULT_VALUE_NOT_SUPPORTED = "Kwalify mapping default value is not supported by JSON Schema and is ignored"
   end
 end

--- a/test/conversion/json_schema/json/sequence_unique.json
+++ b/test/conversion/json_schema/json/sequence_unique.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "sequence_unique",
+  "title": "Conversion of sequence_unique",
+  "description": "Test a sequence with unique items",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "type": "string"
+  }
+}

--- a/test/conversion/json_schema/yaml/unsupported_unique#issues_to_description.yaml
+++ b/test/conversion/json_schema/yaml/unsupported_unique#issues_to_description.yaml
@@ -3,8 +3,12 @@
 title: Conversion of unsupported_unique#issues_to_description
 
 description: |-
-  Test unsupported unique.Issues when converting from Kwalify:
-  * Kwalify 'unique' is not supported by JSON Schema and is ignored
+  Test unsupported unique within a mapping.Issues when converting from Kwalify:
+  * Kwalify 'unique' within a mapping is not supported by JSON Schema and is ignored
 type: array
 items:
-  type: string
+  type: object
+  additionalProperties: false
+  properties:
+    name:
+      type: string

--- a/test/conversion/kwalify/sequence_unique.yaml
+++ b/test/conversion/kwalify/sequence_unique.yaml
@@ -1,0 +1,5 @@
+type: seq
+desc: Test a sequence with unique items
+sequence:
+  - type: str
+    unique: yes

--- a/test/conversion/kwalify/unsupported_unique#issues_to_description.yaml
+++ b/test/conversion/kwalify/unsupported_unique#issues_to_description.yaml
@@ -1,5 +1,8 @@
 type: seq
-desc: Test unsupported unique.
+desc: Test unsupported unique within a mapping.
 sequence:
-  - type: str
-    unique: true
+  - type: map
+    mapping:
+     "name":
+        type: str
+        unique: yes


### PR DESCRIPTION
This adds support for translating a Kwalify `unique` constraint on items in a `seq` to a `uniqueItems` attribute on a JSON schema `array`. Partially fixes #5.